### PR TITLE
update read_dicom to pydicom.filereader.dcmread as per pydicom 3.0.0

### DIFF
--- a/voxel/io/dicom.py
+++ b/voxel/io/dicom.py
@@ -85,7 +85,7 @@ def _separate_enhanced_slices(data_in):
 def _safe_dicom_read(file_path, force=True):
     """Read a dicom file without crashing if a non-dicom file is encountered."""
     try:
-        return pydicom.read_file(file_path, force=force)
+        return pydicom.filereader.dcmread(file_path, force=force)
     except pydicom.errors.InvalidDicomError:
         return None
 


### PR DESCRIPTION
# Description

Dear all,

As previously discussed, pydicom 3.0.0 introduced a [breaking change](https://pydicom.github.io/pydicom/stable/release_notes/index.html) affecting how DICOM files are read.
To address this, I have updated the _safe_dicom_read() function in voxel/io/dicom.py to handle the updated function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

```
def _safe_dicom_read(file_path, force=True):
    """Read a dicom file without crashing if a non-dicom file is encountered."""
    try:
        return pydicom.filereader.dcmread(file_path, force=force)
    except pydicom.errors.InvalidDicomError:
        return None
```

## How Has This Been Tested?

The updated function was tested under the following conditions:

- Valid DICOM files: Verified proper reading of standard DICOM files.
- Cross-platform testing:
    - Google Colab with Python 3.10.12.
    - Ubuntu 24.04 with Python 3.9.18 in a clean conda environment.
 
Please let me know if further adjustments are needed.
